### PR TITLE
now renewing token when opening a client

### DIFF
--- a/vaultprojectkeyring/vaultbackend.py
+++ b/vaultprojectkeyring/vaultbackend.py
@@ -35,7 +35,7 @@ class VaultProjectKeyring(keyring.backend.KeyringBackend):
         self.vault_backend = vault_backend
 
     def __get_client(self):
-        return hvac.Client(
+        client = hvac.Client(
             self.url,
             token=self.token,
             cert=self.cert,
@@ -43,6 +43,8 @@ class VaultProjectKeyring(keyring.backend.KeyringBackend):
             timeout=self.timeout,
             proxies=self.proxies
         )
+        client.renew_token()
+        return client
 
     def __get_path(self, servicename, username):
         if username:


### PR DESCRIPTION
Having to manage the token out of band is annoying. This little change should ensure that the token will not expire in common scenarios (unless forced to elsewhere).