### PR TITLE
Add support for K/V Version 2 secrets engine

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[options.entry_points]
+keyring.backends =
+    vault = vaultprojectkeyring.vaultbackend

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from setuptools import setup, find_packages
 
 
 setup(
     name='keyring-vault-backend',
-    version='1.2.1',
+    version='1.3.0',
     description='Hashicorp vault backend for python-keyring',
     author='Philipp Schmitt',
     author_email='philipp.schmitt@post.lu',

--- a/vaultprojectkeyring/__init__.py
+++ b/vaultprojectkeyring/__init__.py
@@ -1,1 +1,1 @@
-from vaultprojectkeyring.vaultbackend import VaultProjectKeyring
+from .vaultbackend import VaultProjectKeyring

--- a/vaultprojectkeyring/secretbackend.py
+++ b/vaultprojectkeyring/secretbackend.py
@@ -1,0 +1,128 @@
+from datetime import datetime
+import hvac
+
+
+class VaultProjectKeyringSecretBackend(object):
+    def __init__(self, client, backend, secret_prefix=None, interval=None):
+        self.client = client
+        self.interval = interval
+        self.backend = backend
+        self.secret_prefix = secret_prefix
+        self.last_renewed = None
+        self.logic_backend = None
+
+    def get_path(self, entry):
+        if self.secret_prefix is not None:
+            return "/".join([self.secret_prefix] + list(entry))
+        return "/".join(entry)
+
+    def renew_token(self):
+        if self.interval is None:
+            return
+        if type(self.interval) is not int:
+            raise TypeError("Interval value is not an int")
+        try:
+            if self.last_renewed is None or (datetime.now() - self.last_renewed).total_seconds() > self.interval:
+                self.client.renew_token()
+                self.last_renewed = datetime.now()
+        except hvac.exceptions.InvalidRequest as e:
+            raise RuntimeError("Reniew of Vault Token failed: {}".format(e))
+
+    def get_password(self, entry):
+        self.renew_token()
+        return self._get_password(entry)
+
+    def set_password(self, entry, value):
+        self.renew_token()
+        return self._set_password(entry, value)
+
+    def delete_password(self, entry):
+        self.renew_token()
+        value = self._get_password(entry)
+        if self._delete_password(entry):
+            return value
+        else:
+            return False
+
+    def _get_password(self, entry):
+        raise NotImplementedError
+
+    def _set_password(self, entry, value):
+        raise NotImplementedError
+
+    def _delete_password(self, entry):
+        raise NotImplementedError
+
+
+class VaultProjectKeyringKvV1Backend(VaultProjectKeyringSecretBackend):
+    def __init__(self, client, backend, secret_prefix=None, interval=None):
+        super().__init__(client, backend, secret_prefix, interval)
+        self.logic_backend = self.client.secrets.kv.v1
+
+    def _get_password(self, entry):
+        try:
+            result = self.logic_backend.read_secret(path=self.get_path(entry), mount_point=self.backend)
+            return result["data"] if result else None
+        except hvac.exceptions.InvalidPath:
+            return None
+
+    def _set_password(self, entry, value):
+        return self.logic_backend.create_or_update_secret(path=self.get_path(entry),
+                                                          mount_point=self.backend,
+                                                          secret={"password": value})
+
+    def _delete_password(self, entry):
+        return self.logic_backend.delete_secret(path=self.get_path(entry),
+                                                mount_point=self.backend)
+
+
+class VaultProjectKeyringKvV2Backend(VaultProjectKeyringSecretBackend):
+    def __init__(self, client, backend, secret_prefix=None, interval=None):
+        super().__init__(client, backend, secret_prefix, interval)
+        self.logic_backend = self.client.secrets.kv.v2
+
+    def _get_password(self, entry):
+        try:
+            result = self.logic_backend.read_secret_version(self.get_path(entry),
+                                                            mount_point=self.backend)
+            return result["data"]["data"] if result else None
+        except hvac.exceptions.InvalidPath:
+            return None
+
+    def _set_password(self, entry, value):
+        secrets = self._get_password(entry)
+        secrets = secrets if secrets else {}
+        secrets["password"] = value
+        return self.logic_backend.create_or_update_secret(self.get_path(entry),
+                                                          mount_point=self.backend,
+                                                          secret=secrets)
+
+    def _delete_password(self, entry):
+        secrets = self._get_password(entry)
+        del secrets["password"]
+        return self.logic_backend.create_or_update_secret(self.get_path(entry),
+                                                          mount_point=self.backend,
+                                                          secret=secrets)
+
+
+secret_backend_mapping = {
+    "kv_v1": VaultProjectKeyringKvV1Backend,
+    "kv_v2": VaultProjectKeyringKvV2Backend
+}
+
+
+def get_secret_backend(client, backend, backend_type=None, secret_prefix=None, interval=None):
+    if backend_type is None:
+        if backend == "cubbyhole":
+            backend_type = "kv_v1"
+        else:
+            backends_list = client.sys.list_mounted_secrets_engines()
+            secret_backend = next(iter([bck for key, bck in backends_list.items() if key == "{}/".format(backend)]), None)
+            if secret_backend is None:
+                raise ValueError("Unable to find {} Backend".format(backend))
+            if "options" in secret_backend and "version" in secret_backend.get("options", {}):
+                backend_type = "{}_v{}".format(secret_backend.get("type"), secret_backend.get("options").get("version"))
+    backend_impl = secret_backend_mapping.get(backend_type)
+    if backend_impl is None:
+        raise ValueError("Backend type handler not found")
+    return backend_impl(client, backend, secret_prefix, interval)

--- a/vaultprojectkeyring/vaultbackend.py
+++ b/vaultprojectkeyring/vaultbackend.py
@@ -2,40 +2,73 @@
 # coding: utf-8
 
 from __future__ import print_function
-from datetime import datetime
-from hvac.exceptions import InvalidRequest
-import hvac
-import keyring.backend
+
+from functools import lru_cache
+from keyring.backend import KeyringBackend
+from keyring.errors import ExceptionRaisedContext
+from keyring.util import properties
+from os import environ
+from sys import stderr
+
+try:
+    import hvac
+except ImportError:
+    pass
+
 import logging
-import os
-import sys
+
+from .secretbackend import get_secret_backend
 
 # logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-class VaultProjectKeyring(keyring.backend.KeyringBackend):
+class VaultProjectKeyring(KeyringBackend):
     '''
     Keyring backend backed by the vaultproject
     '''
-    priority = 1
 
-    def __init__(self, url=None, token=None, cert=None, verify=None,
-                 timeout=None, proxies=None, vault_backend='keyring'):
-        self.url = url if url else os.environ.get(
-            'VAULT_ADDR', 'http://localhost:8200'
-        )
-        self.token = token if token else os.environ.get('VAULT_TOKEN', None)
+    def __init__(self, url=None, token=None, cert=None, verify=None, interval=None,
+                 timeout=None, proxies=None,
+                 vault_backend='keyring', backend_type=None, secret_prefix=None):
+
+        self.url = url if url else environ.get('VAULT_ADDR', 'http://localhost:8200')
+        self.token = token if token else environ.get('VAULT_TOKEN', None)
+
         if verify is not None:
             self.verify = verify
         else:
-            self.verify = 'VAULT_SKIP_VERIFY' not in os.environ
+            self.verify = 'VAULT_SKIP_VERIFY' not in environ
+
         self.cert = cert
         self.timeout = timeout
         self.proxies = proxies
-        self.vault_backend = vault_backend
 
-    def __get_client(self):
+        self.vault_backend = vault_backend
+        self.backend_type = backend_type
+        self.secret_prefix = secret_prefix
+        self.interval = interval
+
+        # don't initialise client/secret_backend here as __init__ is called during backend discovery
+
+    @properties.ClassProperty
+    @classmethod
+    def priority(cls):
+        if not cls._has_hvac():
+            raise RuntimeError("Requires hvac")
+        if "KEYRING_VAULT_BACKEND" in environ:
+            return 6
+        return 1
+
+    @classmethod
+    def _has_hvac(cls):
+        with ExceptionRaisedContext() as exc:
+            hvac.__name__
+        return not bool(exc)
+
+    @property
+    @lru_cache(maxsize=None)
+    def client(self):
         return hvac.Client(
             self.url,
             token=self.token,
@@ -45,89 +78,55 @@ class VaultProjectKeyring(keyring.backend.KeyringBackend):
             proxies=self.proxies
         )
 
-    def __get_path(self, servicename, username):
-        if username:
-            return '{}/{}/{}'.format(self.vault_backend, servicename, username)
-        else:
-            return '{}/{}'.format(self.vault_backend, servicename)
+    @property
+    @lru_cache(maxsize=None)
+    def secret_backend(self):
+        return get_secret_backend(self.client, self.vault_backend, self.backend_type, self.secret_prefix, self.interval)
+
+    def get_password(self, servicename, username):
+        response = self.secret_backend.get_password((servicename, username))
+        if response:
+            return response['password']
 
     def set_password(self, servicename, username, password):
-        client = self.__get_client()
         try:
-            client.write(
-                self.__get_path(servicename, username),
-                password=password
-            )
+            return self.secret_backend.set_password((servicename, username), password)
         except Exception as e:
             return keyring.errors.PasswordSetError(e.message)
 
-    def get_password(self, servicename, username):
-        client = self.__get_client()
-        response = client.read(self.__get_path(servicename, username))
-        if response:
-            return response['data']['password']
-
     def delete_password(self, servicename, username):
-        client = self.__get_client()
         try:
-            return client.delete(self.__get_path(servicename, username))
+            return self.secret_backend.delete_password((servicename, username))
         except Exception as e:
             return keyring.errors.PasswordDeleteError(e.message)
 
 
-class AutoRenewingTokenKeyring(VaultProjectKeyring):
-    def __init__(self, interval=300, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.token is None:
-            raise keyring.errors.InitError("You cannot use "
-                                           "AutoRenewingTokenKeyring without "
-                                           "an existing vault token")
-        self.interval = interval
-        self.last_renewed = None
-
-    def _VaultProjectKeyring__get_client(self):
-        client = hvac.Client(
-            self.url,
-            token=self.token,
-            cert=self.cert,
-            verify=self.verify,
-            timeout=self.timeout,
-            proxies=self.proxies
-        )
-        try:
-            if self.last_renewed is None or \
-                    (datetime.now() - self.last_renewed
-                     ).total_seconds() > self.interval:
-                client.renew_token()
-                self.last_renewed = datetime.now()
-        except InvalidRequest as e:
-            logger.error("Vault token cannot be renewed: %s"
-                         % e.args[0])
-        return client
-
-
 if __name__ == '__main__':
-    sample_service = 'sample-service'
-    sample_username = 'pschmitt'
-    sample_password = 'fo0bar'
+    import keyring
+
+    test_service = 'test-service'
+    test_username = 'test-user'
+    test_password = 'test-P4$$w0rd!'
 
     # set the keyring for keyring lib
-    keyring.set_keyring(VaultProjectKeyring())
+    keyring.set_keyring(VaultProjectKeyring(vault_backend='cubbyhole'))
+    # keyring.set_keyring(VaultProjectKeyring(vault_backend='keyring1'))
+    # keyring.set_keyring(VaultProjectKeyring(vault_backend='keyring2'))
 
     try:
-        keyring.set_password(sample_service, sample_username, sample_password)
+        keyring.set_password(test_service, test_username, test_password)
         print('Password stored sucessfully')
     except keyring.errors.PasswordSetError:
-        print('Failed to store password', file=sys.stderr)
+        print('Failed to store password', file=stderr)
 
-    assert keyring.get_password(sample_service, sample_username) \
-           == sample_password, 'Failed to retrieve password'
+    assert keyring.get_password(test_service, test_username) \
+        == test_password, 'Failed to retrieve password'
 
     try:
-        keyring.delete_password(sample_service, sample_username)
+        keyring.delete_password(test_service, test_username)
         print('Password deleted sucessfully')
     except keyring.errors.PasswordSetError:
-        print('Failed to delete password', file=sys.stderr)
+        print('Failed to delete password', file=stderr)
 
-    assert not keyring.get_password(sample_service, sample_username), \
+    assert not keyring.get_password(test_service, test_username), \
         'get_password does NOT return None when the service is not known to vault'


### PR DESCRIPTION
* Add support for K/V Version 2 secrets engine (thanks to @jynolen for
  the kickstart via the abandoned PR #5)!
* Add support for nesting secrets beneath the root of a K/V mount point
  via `secret_prefix` parameter.
* Simplify token auto-renewal logic with `interval` parameter.
* Add keyring.backends entry_point configuration for backend
  auto-discovery.